### PR TITLE
Move high_score location to system ram

### DIFF
--- a/defs/userram.asm
+++ b/defs/userram.asm
@@ -1,9 +1,9 @@
 ; ram starts at $C880 til $CBEA
 ; store the scores
-player_score    EQU $C880 ; this is 6 bytes.
-high_score      EQU player_score+7 ; 6 bytes again
+high_score      EQU $CBEB ; 7 bytes at system memory high score location (last byte is terminator 0x80)
+player_score    EQU $C880 ; 7 bytes for player score (last byte is terminator 0x80)
 
-player_x        EQU high_score+7
+player_x        EQU player_score+7
 player_y        EQU player_x+1
 bullet_active   EQU player_y+1 ; stores a 1 if a bullet is active on the screen.
 bullet_x        EQU bullet_active+1 ; the bullets x cord


### PR DESCRIPTION
Hi, 

Nice game, and under 700 bytes!  

I made a slight change here that moves the high_score location to the dedicated 7 bytes available in system ram.  This allows the [open source VEXTREME flash based vectrex multicart](https://github.com/technobly/VEXTREME) to save the high score automatically for the game.  The next time the game is played, the high score is recalled as well.

I'm also curious if you would give me permission to include your game on VEXTREME so more people can play it?

BTW I assembled this with [VIDE](http://vide.malban.de/what-is-vide) and play tested it a bunch.  My high score so far is 15,600 :D

Best regards,
Brett Walach
www.PlayVectrex.com
